### PR TITLE
make New() take nsq-like log func instead of Logger

### DIFF
--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -71,17 +71,10 @@ type tbLog interface {
 	Log(...interface{})
 }
 
-type testLogger struct {
-	tbLog
-}
-
-func (tl *testLogger) Output(maxdepth int, s string) error {
-	tl.Log(s)
-	return nil
-}
-
-func NewTestLogger(tbl tbLog) Logger {
-	return &testLogger{tbl}
+func NewTestLogger(tbl tbLog) AppLogFunc {
+	return func(lvl LogLevel, f string, args ...interface{}) {
+		tbl.Log(fmt.Sprintf(lvl.String()+": "+f, args...))
+	}
 }
 
 func TestDiskQueue(t *testing.T) {


### PR DESCRIPTION
... to finish up log-level support in nsqd

I wanted to make some use of `nsq/internal/lg` but

> .../src/github.com/nsqio/go-diskqueue/diskqueue.go:17:2: use of internal package not allowed

But wait and see the companion nsq PR, the LogLevel type makes things ugly, it would have been better as an int.