### PR TITLE
fix go test

### DIFF
--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -48,7 +48,7 @@ func NotNil(t *testing.T, object interface{}) {
 	if isNil(object) {
 		_, file, line, _ := runtime.Caller(1)
 		t.Logf("\033[31m%s:%d:\n\n\tExpected value not to be <nil>\033[39m\n\n",
-			filepath.Base(file), line, object)
+			filepath.Base(file), line)
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
fix go test with error:
```
# github.com/nsqio/go-diskqueue
./diskqueue_test.go:50: Logf call needs 2 args but has 3 args
FAIL    github.com/nsqio/go-diskqueue [build failed]
```
with `go v1.10`.