### PR TITLE
write to next file if  writePos == maxBytesPerFile

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -387,7 +387,7 @@ func (d *diskQueue) writeOne(data []byte) error {
 	d.writePos += totalBytes
 	atomic.AddInt64(&d.depth, 1)
 
-	if d.writePos > d.maxBytesPerFile {
+	if d.writePos >= d.maxBytesPerFile {
 		d.writeFileNum++
 		d.writePos = 0
 

--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -110,7 +110,7 @@ func TestDiskQueueRoll(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	msg := bytes.Repeat([]byte{0}, 10)
 	ml := int64(len(msg))
-	dq := New(dqName, tmpDir, 9*(ml+4), int32(ml), 1<<10, 2500, 2*time.Second, l)
+	dq := New(dqName, tmpDir, 10*(ml+4), int32(ml), 1<<10, 2500, 2*time.Second, l)
 	defer dq.Close()
 	NotNil(t, dq)
 	Equal(t, int64(0), dq.Depth())


### PR DESCRIPTION
when d.writePos == maxBytesPerFile,  "writeOne" func continues to write a message to current file, this will make current file one message larger than  expected.