### PR TITLE
Support go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+  - 1.x
+notifications:
+  email: false
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # go-diskqueue
+
+[![Build Status](https://secure.travis-ci.org/nsqio/go-diskqueue.png?branch=master)](http://travis-ci.org/nsqio/go-diskqueue) [![GoDoc](https://godoc.org/github.com/nsqio/go-diskqueue?status.svg)](https://godoc.org/github.com/nsqio/go-diskqueue) [![GitHub release](https://img.shields.io/github/release/nsqio/go-diskqueue.svg)](https://github.com/nsqio/go-diskqueue/releases/latest)
+
 A Go package providing a filesystem-backed FIFO queue
 
 Pulled out of https://github.com/nsqio/nsq

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nsqio/go-diskqueue
+
+go 1.13


### PR DESCRIPTION
This adds support of go modules in prep of a 1.0.0 release of go-diskqueue

cc: @ploxiln @mreiferson