### PR TITLE
change dq.Depth() to request & response model

### DIFF
--- a/diskqueue_test.go
+++ b/diskqueue_test.go
@@ -123,6 +123,11 @@ func TestDiskQueueRoll(t *testing.T) {
 
 	Equal(t, int64(1), dq.(*diskQueue).writeFileNum)
 	Equal(t, int64(0), dq.(*diskQueue).writePos)
+
+	for i := 10; i > 0; i-- {
+		Equal(t, msg, <-dq.ReadChan())
+		Equal(t, int64(i-1), dq.Depth())
+	}
 }
 
 func assertFileNotExist(t *testing.T, fn string) {


### PR DESCRIPTION
```
for i := 0; i < 10; i++ {
	err := dq.Put(msg)
	Nil(t, err)
	Equal(t, int64(i+1), dq.Depth())
}

for i := 10; i > 0; i-- {
	<-dq.ReadChan()
	fmt.Println(dq.Depth())
}
```
When i run such codes above, i get result like this.
```
10
8
8
6
6
4
4
2
2
0
```



```
line638: case r <- dataRead:
line639:	count++
line640:	// moveForward sets needSync flag if a file is removed
line641: 	d.moveForward()
```

when executes at line638, ```<-dq.ReadChan``` will get result and continue, then we got wrong depth, because ```line641 d.moveForward()``` is not reached.

I send a signal to notice i want to get depth,  it will run with  ```<-dataRead``` in serial and get expected result.




