### PR TITLE
Inaccurate depth count after readError on "current" file

### DIFF
--- a/diskqueue.go
+++ b/diskqueue.go
@@ -608,6 +608,8 @@ func (d *diskQueue) handleReadError() {
 
 	// significant state change, schedule a sync on the next iteration
 	d.needSync = true
+
+	d.checkTailCorruption(d.depth)
 }
 
 // ioLoop provides the backend for exposing a go channel (via ReadChan())


### PR DESCRIPTION
Fixes nsqio/go-diskqueue#29